### PR TITLE
Add bower.json and tag as 0.2.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,6 @@
+{
+  "name": "ng-mobile-menu",
+  "version": "0.2.1",
+  "main": "dist/ng-mobile-menu.js",
+  "description": "An AngularJS module that provides a CSS slide out menu for mobile apps like the Facebook iOS app."
+}

--- a/demo/ng-mobile-menu.min.js
+++ b/demo/ng-mobile-menu.min.js
@@ -1,3 +1,3 @@
-/*! ng-mobile-menu - v0.2.0 - 2013-07-17
-* Copyright (c) 2013 Jeff French; Licensed MIT */
+/*! ng-mobile-menu - v0.2.1 - 2014-02-07
+* Copyright (c) 2014 Jeff French; Licensed MIT */
 angular.module("shoppinpal.mobile-menu",[]).run(["$rootScope","$spMenu",function(a,b){a.$spMenu=b}]).provider("$spMenu",function(){this.$get=[function(){var a={};return a.show=function(){var a=angular.element(document.querySelector("#sp-nav"));console.log(a),a.addClass("show")},a.hide=function(){var a=angular.element(document.querySelector("#sp-nav"));a.removeClass("show")},a.toggle=function(){var a=angular.element(document.querySelector("#sp-nav"));a.toggleClass("show")},a}]});

--- a/dist/ng-mobile-menu.min.js
+++ b/dist/ng-mobile-menu.min.js
@@ -1,3 +1,3 @@
-/*! ng-mobile-menu - v0.2.0 - 2013-07-17
-* Copyright (c) 2013 Jeff French; Licensed MIT */
+/*! ng-mobile-menu - v0.2.1 - 2014-02-07
+* Copyright (c) 2014 Jeff French; Licensed MIT */
 angular.module("shoppinpal.mobile-menu",[]).run(["$rootScope","$spMenu",function(a,b){a.$spMenu=b}]).provider("$spMenu",function(){this.$get=[function(){var a={};return a.show=function(){var a=angular.element(document.querySelector("#sp-nav"));console.log(a),a.addClass("show")},a.hide=function(){var a=angular.element(document.querySelector("#sp-nav"));a.removeClass("show")},a.toggle=function(){var a=angular.element(document.querySelector("#sp-nav"));a.toggleClass("show")},a}]});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-mobile-menu",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "An AngularJS module that provides a CSS slide out menu for mobile apps like the Facebook iOS app.",
   "main": "Gruntfile.js",
   "repository": {


### PR DESCRIPTION
`grunt-bower-install` (used by Yeoman's `generator-angular`) infers files paths according to the `main` property provided in bower.json. Without a `main`, manual configuration of index.html is required.
